### PR TITLE
rename to prod

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,6 +1,6 @@
 services:
   - type: web
-    name: Backend Dev
+    name: Backend Prod
     runtime: image
     image:
       url: ghcr.io/pax-fin/be-app:main

--- a/render.yaml
+++ b/render.yaml
@@ -1,6 +1,6 @@
 services:
   - type: web
-    name: Backend Prod
+    name: prod-backend
     runtime: image
     image:
       url: ghcr.io/pax-fin/be-app:main


### PR DESCRIPTION
- rename now
- when I add tagging, we can change the creds
- still debating on rename... could be something like `releases`... `production` sounds lame
  - until we have stuff other than render, I am ok to keep as-is